### PR TITLE
add test of earlier fix for FCB#instance_variables type on 1.8.x

### DIFF
--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -217,4 +217,18 @@ describe Docile do
 
   end
 
+  context "FallbackContextProxy#instance_variables" do
+
+    it "should preserve the class (String or Symbol) normally returned by current ruby version" do
+      @a = 1
+      expected_type = instance_variables.first.class
+
+      fcp = Docile::FallbackContextProxy.new(nil, nil)
+      fcp.instance_variable_set(:@foo, "foo")
+
+      fcp.instance_variables.first.class.should == expected_type
+    end
+
+  end
+
 end


### PR DESCRIPTION
Earlier fix d06b580fe06f593f88b3f67088765e7984a0a13b "Modify 1.8.x compatibility fix to preserve original return type" did not come with a test case which failed on 1.8.x. This is that missing test.
