### PR TITLE
tests: make simplecov/coveralls optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,24 @@
-require 'simplecov'
-require 'coveralls'
+begin
+  require 'simplecov'
+  require 'coveralls'
 
-# On Ruby 1.9+ use SimpleCov and publish to Coveralls.io
-if !RUBY_VERSION.start_with? '1.8'
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
-  SimpleCov.start do
-    add_filter '/spec/'    # exclude test code
-    add_filter '/vendor/'  # exclude gems which are vendored on Travis CI
+  # On Ruby 1.9+ use SimpleCov and publish to Coveralls.io
+  if !RUBY_VERSION.start_with? '1.8'
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+    SimpleCov.start do
+      add_filter '/spec/'    # exclude test code
+      add_filter '/vendor/'  # exclude gems which are vendored on Travis CI
+    end
+
+    # Remove Docile, which was required by SimpleCov, to require again later
+    Object.send(:remove_const, :Docile)
+    $LOADED_FEATURES.reject! { |f| f =~ /\/docile\// }
   end
-
-  # Remove Docile, which was required by SimpleCov, to require again later
-  Object.send(:remove_const, :Docile)
-  $LOADED_FEATURES.reject! { |f| f =~ /\/docile\// }
+rescue LoadError
+  warn 'warning: simplecov/coveralls gems not found; skipping coverage'
 end
 
 lib_dir = File.join(File.dirname(File.dirname(__FILE__)), 'lib')


### PR DESCRIPTION
If we do not have SimpleCov or Coveralls installed, we should be able to continue with the rest of the test suite.

This allows the tests to run outside of Bundler if SimpleCov or Coveralls are not installed.
