### PR TITLE
Remove jruby-9.1 from Travis due to failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rvm:
   - ree
   # JRuby
   - jruby-head
-  - jruby-9.1
+  - jruby-9.1 # allowed to fail due to https://github.com/travis-ci/travis-ci/issues/9049
   - jruby-9.0
   - jruby-19mode
   - jruby-18mode
@@ -32,5 +32,6 @@ matrix:
     - rvm: ruby-head
     - rvm: 1.9.2 # See build error https://travis-ci.org/tcrayford/Values/jobs/202728857
     - rvm: jruby-head
+    - rvm: jruby-9.1 # See build error https://travis-ci.org/ms-ati/docile/jobs/327830706
     - rvm: rubinius-3
   fast_finish: true


### PR DESCRIPTION
See
  - https://github.com/travis-ci/travis-ci/issues/9049
  - https://travis-ci.org/ms-ati/docile/jobs/327830706