### PR TITLE
Allow helper methods defined in the block's context to call DSL

### DIFF
--- a/lib/docile/execution.rb
+++ b/lib/docile/execution.rb
@@ -22,8 +22,13 @@ module Docile
           value_from_block = block_context.instance_variable_get(ivar)
           proxy_context.instance_variable_set(ivar, value_from_block)
         end
+
         proxy_context.instance_exec(*args, &block)
       ensure
+        if block_context.respond_to?(:__docile_undo_fallback__)
+          block_context.send(:__docile_undo_fallback__)
+        end
+
         block_context.instance_variables.each do |ivar|
           value_from_dsl_proxy = proxy_context.instance_variable_get(ivar)
           block_context.instance_variable_set(ivar, value_from_dsl_proxy)


### PR DESCRIPTION
Previously, it turns out that this wasn't possible, which made
refactoring code that used Docile to extract common helper methods,
and re-use them in different blocks, a painful experience.

This change should make it possible to extract methods from blocks
into the context around the block, and have those extracted helper
methods still able to call methods on the DSL object.