### PR TITLE
Filter Docile's source files from backtrace

### DIFF
--- a/lib/docile.rb
+++ b/lib/docile.rb
@@ -2,6 +2,7 @@ require "docile/version"
 require "docile/execution"
 require "docile/fallback_context_proxy"
 require "docile/chaining_fallback_context_proxy"
+require "docile/backtrace_filter"
 
 # Docile keeps your Ruby DSLs tame and well-behaved.
 module Docile

--- a/lib/docile/backtrace_filter.rb
+++ b/lib/docile/backtrace_filter.rb
@@ -2,9 +2,9 @@ module Docile
   # @api private
   #
   # This is used to remove entries pointing to Docile's source files
-  # from Exception#backtrace/Exception#backtrace_locations.
+  # from {Exception#backtrace} and {Exception#backtrace_locations}.
   #
-  # If NoMethodError is catched then the exception object will be extended
+  # If {NoMethodError} is caught then the exception object will be extended
   # by this module to add filter functionalities.
   module BacktraceFilter
     FILTER_PATTERN = /lib\/docile/

--- a/lib/docile/backtrace_filter.rb
+++ b/lib/docile/backtrace_filter.rb
@@ -1,0 +1,22 @@
+module Docile
+  # @api private
+  #
+  # This is used to remove entries pointing to Docile's source files
+  # from Exception#backtrace/Exception#backtrace_locations.
+  #
+  # If NoMethodError is catched then the exception object will be extended
+  # by this module to add filter functionalities.
+  module BacktraceFilter
+    FILTER_PATTERN = /lib\/docile/
+
+    def backtrace
+      super.select { |trace| trace !~ FILTER_PATTERN }
+    end
+
+    if ::Exception.public_method_defined?(:backtrace_locations)
+      def backtrace_locations
+        super.select { |location| location.absolute_path !~ FILTER_PATTERN }
+      end
+    end
+  end
+end

--- a/lib/docile/fallback_context_proxy.rb
+++ b/lib/docile/fallback_context_proxy.rb
@@ -86,7 +86,12 @@ module Docile
       if @__receiver__.respond_to?(method.to_sym)
         @__receiver__.__send__(method.to_sym, *args, &block)
       else
-        @__fallback__.__send__(method.to_sym, *args, &block)
+        begin
+          @__fallback__.__send__(method.to_sym, *args, &block)
+        rescue NoMethodError => e
+          e.extend(BacktraceFilter)
+          raise e
+        end
       end
     end
   end

--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -416,6 +416,25 @@ describe Docile do
       end
     end
 
+    context "when NoMethodError is raised" do
+      specify "#backtrace does not include path to Docile's source file" do
+        begin
+          Docile.dsl_eval(Object.new) { foo }
+        rescue NoMethodError => e
+          expect(e.backtrace).not_to include(match(/lib\/docile/))
+        end
+      end
+
+      if ::Exception.public_method_defined?(:backtrace_locations)
+        specify "#backtrace_locations also does not include path to Docile's source file" do
+          begin
+            Docile.dsl_eval(Object.new) { foo }
+          rescue NoMethodError => e
+            expect(e.backtrace_locations.map(&:absolute_path)).not_to include(match(/lib\/docile/))
+          end
+        end
+      end
+    end
   end
 
   describe ".dsl_eval_with_block_return" do


### PR DESCRIPTION
This is implementation of #35.
To do  this, remove entries including path to Docile's source file from `Exception#backtrace` and `Exception#backtrace_locations`.
