### PR TITLE
Short-circuit to `dsl.instance_exec` when `dsl.equal?(block_context)`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased changes](http://github.com/ms-ati/docile/compare/v1.3.4...master)
 
-  - ...
+  - Short-circuit to calling #instance_exec directly on the DSL object (prior to
+    constructing a proxy object) when the DSL object and block context object are
+    identical
 
 ## [v1.3.4 (Dec 22, 2020)](http://github.com/ms-ati/docile/compare/v1.3.3...v1.3.4)
 

--- a/lib/docile/execution.rb
+++ b/lib/docile/execution.rb
@@ -16,6 +16,13 @@ module Docile
     # @return           [Object] the return value of the block
     def exec_in_proxy_context(dsl, proxy_type, *args, &block)
       block_context = eval("self", block.binding)
+
+      # Use #equal? to test strict object identity (assuming that this dictum
+      # from the Ruby docs holds: "[u]nlike ==, the equal? method should never
+      # be overridden by subclasses as it is used to determine object
+      # identity")
+      return dsl.instance_exec(*args, &block) if dsl.equal?(block_context)
+
       proxy_context = proxy_type.new(dsl, block_context)
       begin
         block_context.instance_variables.each do |ivar|

--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -414,6 +414,12 @@ describe Docile do
         expect(dsl.foo).to eq(0)
         expect(dsl.bar).to eq(1)
       end
+
+      context "when the DSL object is frozen" do
+        it "can call non-mutative code without raising an exception" do
+          expect { dsl.freeze.dsl_eval_string('1 + 2') }.not_to raise_error
+        end
+      end
     end
 
     context "when NoMethodError is raised" do


### PR DESCRIPTION
I ran into an issue invoking `Docile.dsl_eval_with_block_return` using a frozen object as the DSL
object, even though none of the code in the evaluated block attempts to mutate the frozen object:

```ruby
# do_something.rb

require 'docile'

class MyClass
  def initialize
    @something = proc { puts "Hello!" }
  end

  def evaluate(*args, &block)
    Docile.dsl_eval_with_block_return(self, *args, &block)
  end

  def something
    @something = Proc.new if block_given?
    @something
  end

  def do_something
    evaluate(&something)
  end
end

MyClass.new.do_something
MyClass.new.tap { |mc| mc.something { puts "Goodbye!" } }.freeze.do_something
MyClass.new.freeze.do_something
```

```
$ ruby ./do_something.rb
Hello!
Goodbye!
Traceback (most recent call last):
        9: from -e:1:in `<main>'
        8: from -e:1:in `load'
        7: from /path/to/do_something.rb:26:in `<top (required)>'
        6: from /path/to/do_something.rb:20:in `do_something'
        5: from /path/to/do_something.rb:11:in `evaluate'
        4: from /usr/lib/ruby/gems/2.5.0/gems/docile-1.3.2/lib/docile.rb:83:in `dsl_eval_with_block_return'
        3: from /usr/lib/ruby/gems/2.5.0/gems/docile-1.3.2/lib/docile/execution.rb:19:in `exec_in_proxy_context'
        2: from /usr/lib/ruby/gems/2.5.0/gems/docile-1.3.2/lib/docile/execution.rb:19:in `new'
        1: from /usr/lib/ruby/gems/2.5.0/gems/docile-1.3.2/lib/docile/fallback_context_proxy.rb:55:in `initialize'
/nix/store/rlgw8kj33z52s53crdsjdb83wrh63550-ruby2.5.7-docile-1.3.2/lib/ruby/gems/2.5.0/gems/docile-1.3.2/lib/docile/fallback_context_proxy.rb:55:in `define_method': can't modify frozen object (FrozenError)
```

The proximate cause of the error appears to be calling `#define_method` on the frozen object.

Given that, in the scenario that results in a `FrozenError`, the DSL object and the block context
object are identical, it looks like it should be possible to short-circuit to calling
`#instance_exec` on the DSL object rather than setting up a proxy object.  This PR implements
exactly this short-circuit.

Thanks in advance for your consideration!