### PR TITLE
Allow travis failures of 1.8.7 and REE for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
     # NOTE (2020-12-18): Failing access to Rubygems with following error:
     #   Unable to download data from https://rubygems.org/ - hostname was not
     #   match with the server certificate (https://rubygems.org/specs.4.8.gz)
+    #
+    #   See Travis CI topic here:
+    #   https://travis-ci.community/t/ruby-1-8-7-and-ree-builds-broken-by-ssl-certificate-failure/10866
+    #
     # TODO (2020-12-18): Either find a fix or remove testing of 1.8 versions
     - rvm: 1.8.7
     - rvm: ree

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: ruby
 
-# Apparently sudo is required to test on Rubinius and JRuby-head
-sudo: required
-
-# See https://docs.travis-ci.com/user/languages/ruby/#Rubinius
-dist: trusty
+dist: focal
 
 rvm:
   # MRI

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ rvm:
   - 2.2
   - 2.1
   - 1.9.3
-  - 1.8.7
-  - ree
   # JRuby
   - jruby-head
   - jruby-9.2
@@ -31,4 +29,11 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: truffleruby-head
+    # NOTE (2020-12-18): Failing access to Rubygems with following error:
+    #   Unable to download data from https://rubygems.org/ - hostname was not
+    #   match with the server certificate (https://rubygems.org/specs.4.8.gz)
+    # TODO (2020-12-18): Either find a fix or remove testing of 1.8 versions
+    - rvm: 1.8.7
+    - rvm: ree
+
   fast_finish: true


### PR DESCRIPTION
Currently these Travis CI builds are failing to access Rubygems with following error:

    Unable to download data from https://rubygems.org/ - hostname was not
    match with the server certificate (https://rubygems.org/specs.4.8.gz)

This commit simply allows them to fail in CI without failing the entire build. As a
next step, we must either find a way to fix these test builds, or move forwards to
officially remove support for Ruby 1.8.