### PR TITLE
Supply location info to class_eval

### DIFF
--- a/lib/docile/fallback_context_proxy.rb
+++ b/lib/docile/fallback_context_proxy.rb
@@ -88,7 +88,7 @@ module Docile
       else
         "*args, &block"
       end
-    class_eval(<<-METHOD)
+    class_eval(<<-METHOD, __FILE__, __LINE__ + 1)
       def method_missing(method, #{args_string})
         if @__receiver__.respond_to?(method.to_sym)
           @__receiver__.__send__(method.to_sym, #{args_string})

--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -440,7 +440,7 @@ describe Docile do
       context "when a DSL method has a keyword argument" do
         class DSLMethodWithKeywordArgument
           attr_reader :v0, :v1, :v2
-          class_eval(<<-METHOD)
+          class_eval(<<-METHOD, __FILE__, __LINE__ + 1)
             def set(v0, v1:, v2:)
               @v0 = v0
               @v1 = v1


### PR DESCRIPTION
Currently `class_eval` has no location info so caller location of `FallbackContextProxy#method_missing` is not understandable.
(see following example.)
This PR is fix this problem.

For example:

Sample code:

```ruby
require 'docile'

class Foo
  def bar
    puts caller_locations
  end
end

Docile.dsl_eval(Foo.new) { bar }
```

Current caller locations:

```
(eval):3:in `method_missing'
test.rb:9:in `block in <main>'
/opt/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/docile-1.3.3/lib/docile/execution.rb:26:in `instance_exec'
/opt/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/docile-1.3.3/lib/docile/execution.rb:26:in `exec_in_proxy_context'
test.rb:9:in `<main>'
```

Better and expected caller locations:

```
/home/taichi/workspace/ruby_etc/docile/lib/docile/fallback_context_proxy.rb:94:in `method_missing'
test.rb:9:in `block in <main>'
/home/taichi/workspace/ruby_etc/docile/lib/docile/execution.rb:26:in `instance_exec'
/home/taichi/workspace/ruby_etc/docile/lib/docile/execution.rb:26:in `exec_in_proxy_context'
/home/taichi/workspace/ruby_etc/docile/lib/docile.rb:44:in `dsl_eval'
test.rb:9:in `<main>'
``` 