### PR TITLE
Restore testing 1.8.7 and ree in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ rvm:
   - 2.2
   - 2.1
   - 1.9.3
+  - 1.8.7	
+  - ree
   # JRuby
   - jruby-head
   - jruby-9.2


### PR DESCRIPTION
Oops, the intention had been to keep these tests running, but allow them to fail!