### PR TITLE
Add ruby2_keywords to delegating methods

### DIFF
--- a/lib/docile.rb
+++ b/lib/docile.rb
@@ -44,6 +44,8 @@ module Docile
     exec_in_proxy_context(dsl, FallbackContextProxy, *args, &block)
     dsl
   end
+
+  ruby2_keywords :dsl_eval if respond_to?(:ruby2_keywords, true)
   module_function :dsl_eval
 
   # Execute a block in the context of an object whose methods represent the
@@ -83,6 +85,8 @@ module Docile
   def dsl_eval_with_block_return(dsl, *args, &block)
     exec_in_proxy_context(dsl, FallbackContextProxy, *args, &block)
   end
+
+  ruby2_keywords :dsl_eval_with_block_return if respond_to?(:ruby2_keywords, true)
   module_function :dsl_eval_with_block_return
 
   # Execute a block in the context of an immutable object whose methods,
@@ -120,5 +124,7 @@ module Docile
   def dsl_eval_immutable(dsl, *args, &block)
     exec_in_proxy_context(dsl, ChainingFallbackContextProxy, *args, &block)
   end
+  
+  ruby2_keywords :dsl_eval_immutable if respond_to?(:ruby2_keywords, true)
   module_function :dsl_eval_immutable
 end

--- a/lib/docile/chaining_fallback_context_proxy.rb
+++ b/lib/docile/chaining_fallback_context_proxy.rb
@@ -16,5 +16,7 @@ module Docile
     def method_missing(method, *args, &block)
       @__receiver__ = super(method, *args, &block)
     end
+    
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/lib/docile/execution.rb
+++ b/lib/docile/execution.rb
@@ -36,6 +36,8 @@ module Docile
         end
       end
     end
+
+    ruby2_keywords :exec_in_proxy_context if respond_to?(:ruby2_keywords, true)
     module_function :exec_in_proxy_context
   end
 end

--- a/lib/docile/fallback_context_proxy.rb
+++ b/lib/docile/fallback_context_proxy.rb
@@ -61,6 +61,8 @@ module Docile
             end
           end
 
+        singleton_class.send(:ruby2_keywords, :method_missing) if singleton_class.respond_to?(:ruby2_keywords, true)
+
         # instrument a helper method to remove the above instrumentation
         singleton_class.
           send(:define_method, :__docile_undo_fallback__) do
@@ -94,6 +96,7 @@ module Docile
         end
       end
     end
+
     ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -467,6 +467,50 @@ describe Docile do
     end
   end
 
+  context "when a DSL method has a double splat" do
+    class DSLMethodWithDoubleSplat
+      attr_reader :arguments, :options
+
+      def configure(*arguments, **options)
+        @arguments = arguments.dup
+        @options = options.dup
+      end
+    end
+
+    let(:dsl) do
+      DSLMethodWithDoubleSplat.new
+    end
+
+    it "correctly passes keyword arguments" do
+      Docile.dsl_eval(dsl) do
+        configure(1, a: 1)
+      end
+
+      expect(dsl.arguments).to eq [1]
+      expect(dsl.options).to eq({ a: 1 })
+    end
+
+    if RUBY_VERSION < "3.0.0"
+      it "correctly passes hash arguments on Ruby 2" do
+        Docile.dsl_eval(dsl) do
+          configure(1, { a: 1 })
+        end
+
+        expect(dsl.arguments).to eq [1]
+        expect(dsl.options).to eq({ a: 1 })
+      end
+    else
+      it "correctly passes hash arguments on Ruby 3+" do
+        Docile.dsl_eval(dsl) do
+          configure(1, { a: 1 })
+        end
+
+        expect(dsl.arguments).to eq [1, { a: 1 }]
+        expect(dsl.options).to eq({})
+      end
+    end
+  end
+
   describe ".dsl_eval_with_block_return" do
     let(:array) { [] }
     let!(:result) { execute_dsl_against_array }


### PR DESCRIPTION
Pull request for #56. Maybe @eregon could have a look at this?

One thing I am not sure about is if calling `module_function` for a method after calling `ruby2_keywords` works correctly.