### PR TITLE
Introduce Codecov action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,7 @@ jobs:
           bundler-cache: false
       - run: bundle install
       - run: bundle exec rspec
+      - uses: codecov/codecov-action@v1
+        with:
+          name: ${{ matrix.ruby }}
+          file: ./coverage/coverage.xml

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
 # CI-only dependencies go here
-if ENV["CI"] == "true" && RUBY_ENGINE == "ruby"
-  gem "codecov", require: false, group: "test"
+if ENV["CI"] == "true"
+  gem "simplecov-cobertura", require: false, group: "test"
 end
 
 # Specify gem's dependencies in docile.gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,10 +6,11 @@ begin
     add_filter "/vendor/"    # exclude gems which are cached in CI
   end
 
-  # On CI we publish coverage to codecov.io, except on JRuby and TruffleRuby
-  if ENV["CI"] == "true" && RUBY_ENGINE == "ruby"
-    require "codecov"
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  # On CI we publish coverage to codecov.io
+  # To use codecov-action, we need to generate XML based covarage report
+  if ENV["CI"] == "true"
+    require "simplecov-cobertura"
+    SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
   end
 
   # Due to circular dependency (simplecov depends on docile), remove docile and require again below


### PR DESCRIPTION
Hi @ms-ati ,
I've introduce the codecov action to upload coverage reports instead of codecov gem.
This change is to prevent `ArgumentError` raised when uploading coverage reports by using codecov gem.
https://github.com/ms-ati/docile/runs/2511283031?check_suite_focus=true#step:5:101
