### PR TITLE
Use 'bundler-cache' option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: false
-      - run: bundle install
+          bundler-cache: true
       - run: bundle exec rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ begin
 
   # Due to circular dependency (simplecov depends on docile), remove docile and require again below
   Object.send(:remove_const, :Docile)
-  $LOADED_FEATURES.reject! { |f| f =~ /\/docile\// }
+  $LOADED_FEATURES.reject! { |f| f =~ /\/lib\/docile/ }
 rescue LoadError
   warn "warning: simplecov or codecov gems not found; skipping coverage"
 end


### PR DESCRIPTION
Hi @ms-ati ,

This PR is to enable `bundler-cache` option of `setup-ruby` action.

We need to fix  `already initialized constant` warning reported when running RSpec.
https://github.com/ms-ati/docile/runs/2501978917?check_suite_focus=true#step:4:27

To fix this kind of warning, I've changed the condition to remove docile's files from `$LOAD_PATH`.