### PR TITLE
Add metadata to gemspec

### DIFF
--- a/docile.gemspec
+++ b/docile.gemspec
@@ -26,4 +26,10 @@ Gem::Specification.new do |s|
     f.match(%r{^(test|spec|features)/})
   end
   s.require_paths = ["lib"]
+
+  s.metadata = {
+    "homepage_uri" => "https://ms-ati.github.io/docile/",
+    "changelog_uri" => "https://github.com/ms-ati/docile/blob/main/HISTORY.md",
+    "source_code_uri" => "https://github.com/ms-ati/docile",
+  }
 end


### PR DESCRIPTION
Setting `changelog_uri` in `metadata` could help users find the changelog.

The link will be displayed on RubyGems.org.

It also makes the changelog discoverable by tools like https://github.com/envato/unwrappr.

Reference on RubyGems.org:
https://guides.rubygems.org/specification-reference/#metadata