### PR TITLE
Fix Rubocop path to panolint gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 inherit_gem:
-  panolint: rubocop.yml
+  panolint: panolint-rubocop.yml


### PR DESCRIPTION
The Panolint gem changed the name of the file to be inherited to
'panolint-rubocop.yml', so this needs to be updated here.