### PR TITLE
Fix specs on TruffleRuby 22.0.0.2

### DIFF
--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -546,7 +546,8 @@ describe Docile do
       it "correctly passes hash arguments" do
         described_class.dsl_eval(dsl) { configure(1, { a: 1 }) }
 
-        if RUBY_VERSION >= "3.0.0"
+        # TruffleRuby 22.0.0.2 has RUBY_VERSION of 3.0.2, but behaves as 2.x
+        if RUBY_VERSION >= "3.0.0" && RUBY_ENGINE != "truffleruby"
           expect(dsl.arguments).to eq [1, { a: 1 }]
           expect(dsl.options).to eq({})
         else


### PR DESCRIPTION
Appears that TruffleRuby 22.0.0.2 reports RUBY_VERSION of 3.0.2,
but the observed behavior when we pass a hash final argument to
a method taking splat and double-splat arguments appears to be
the prior behavior of Ruby versions before 3.0.0.