### PR TITLE
Move Gemfile CI-only dependencies to test group

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [jruby, truffleruby, 2.5, 2.6, 2.7, '3.0', '3.1', head]
+        ruby: [jruby, truffleruby, 2.5, 2.6, 2.7, '3.0', 3.1, head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,17 @@
 
 source "https://rubygems.org"
 
-# CI-only dependencies go here
-if ENV["CI"] == "true" # rubocop:disable Style/IfUnlessModifier
-  gem "simplecov-cobertura", require: false, group: "test"
-end
-
-# Specify gem's dependencies in docile.gemspec
+# Specify gem's runtime dependencies in docile.gemspec
 gemspec
 
 group :test do
   gem "rspec", "~> 3.10"
   gem "simplecov", require: false
+
+  # CI-only test dependencies go here
+  if ENV["CI"] == "true"
+    gem "simplecov-cobertura", require: false, group: "test"
+  end
 end
 
 # Excluded from CI except on latest MRI Ruby, to reduce compatibility burden


### PR DESCRIPTION
We want to be careful to avoid accidentally bringing
in runtime dependencies to projects which use Docile.

In this PR, clarify explicitly that the CI-only dependency
on `simplecov-cobertura`, which is the formatt used by CodeCov,
is a **test** dependency, and not a runtime dependency.

Without this change, it may be possible that projects which use
Docile, when running in an environment with `CI=true`, would
accidentally bring in this test-only dependency, when that isn't
intended.

**Other changes**
- Remove unnecessary quoting of `'3.1'` in `.github/workflows/main.yml`