### PR TITLE
CI: exclude Gemfile 'checks' group except latest Ruby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.0
+
+      # Conditionally configure bundler via environment variables as advised
+      #   * https://github.com/ruby/setup-ruby#bundle-config
+      - name: Set bundler environment variables
+        run: |
+          echo "BUNDLE_WITHOUT=checks" >> $GITHUB_ENV
+        if: matrix.ruby != 3.1
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
       - run: bundle exec rspec
+
       - uses: codecov/codecov-action@v3.0.0
         with:
           name: ${{ matrix.ruby }}
           file: ./coverage/coverage.xml
+
       - run: bundle exec rubocop
-        if: matrix.ruby == '3.0'
+        if: matrix.ruby == 3.1


### PR DESCRIPTION
Since we only run Rubocop on the latest MRI Ruby, dont
install the "checks" Gemfile group on other rubies in CI.