### PR TITLE
TEST: support ruby 3.3 NoMethodError message

### DIFF
--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -249,7 +249,7 @@ describe Docile do
           expect { push_element }.
             to raise_error(
               NoMethodError,
-              /undefined method `push' (for|on) nil:NilClass/
+              /undefined method `push' (for|on) nil/
             )
         end
       end


### PR DESCRIPTION
ruby 3.3 changes error messages especially for NoMethodError: https://github.com/ruby/ruby/pull/6950
https://bugs.ruby-lang.org/issues/18285

Modify spec to support this new ruby 3.3 error messages.

Closes #105 .