### PR TITLE
Support Ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [jruby, truffleruby, 2.5, 2.6, 2.7, '3.0', 3.1, head]
+        ruby: [jruby, 2.7, '3.0', 3.1, 3.2, 3.3, head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0
@@ -24,7 +24,7 @@ jobs:
       - name: Set bundler environment variables
         run: |
           echo "BUNDLE_WITHOUT=checks" >> $GITHUB_ENV
-        if: matrix.ruby != 3.1
+        if: matrix.ruby != 3.3
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -39,4 +39,4 @@ jobs:
           file: ./coverage/coverage.xml
 
       - run: bundle exec rubocop
-        if: matrix.ruby == 3.1
+        if: matrix.ruby == 3.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 inherit_gem:
   panolint: panolint-rubocop.yml
+
+require:
+  - rubocop-rake

--- a/docile.gemspec
+++ b/docile.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |s|
   s.email       = "marc@usainnov.com"
   s.homepage    = "https://ms-ati.github.io/docile/"
   s.summary     = "Docile keeps your Ruby DSLs tame and well-behaved."
-  s.description = "Docile treats the methods of a given ruby object as a DSL " \
-                  "(domain specific language) within a given block. \n\n"      \
-                  "Killer feature: you can also reference methods, instance "  \
+  s.description = "Docile treats the methods of a given ruby object as a DSL "\
+                  "(domain specific language) within a given block. \n\n"\
+                  "Killer feature: you can also reference methods, instance "\
                   "variables, and local variables from the original (non-DSL) "\
-                  "context within the block. \n\n"                             \
-                  "Docile releases follow Semantic Versioning as defined at "  \
+                  "context within the block. \n\n"\
+                  "Docile releases follow Semantic Versioning as defined at "\
                   "semver.org."
   s.license     = "MIT"
 

--- a/lib/docile/chaining_fallback_context_proxy.rb
+++ b/lib/docile/chaining_fallback_context_proxy.rb
@@ -18,7 +18,7 @@ module Docile
     # Proxy methods as in {FallbackContextProxy#method_missing}, replacing
     # `receiver` with the returned value.
     def method_missing(method, *args, &block)
-      @__receiver__ = super(method, *args, &block)
+      @__receiver__ = super
     end
 
     ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)

--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -224,7 +224,7 @@ describe Docile do
 
         it "raises NoMethodError" do
           expect { subject.call(5) }.
-            to raise_error(NoMethodError, /method `at' /)
+            to raise_error(NoMethodError, /method (`|')at' /)
         end
 
         it "removes fallback instrumentation from the DSL object after block" do
@@ -249,7 +249,7 @@ describe Docile do
           expect { push_element }.
             to raise_error(
               NoMethodError,
-              /undefined method `push' (for|on) nil/
+              /undefined method (`|')push' (for|on) nil/
             )
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ end
 
 # Due to circular dependency (SimpleCov depends on Docile), remove docile and
 # then require the docile gem again below.
-Object.send(:remove_const, :Docile)
+Object.send(:remove_const, :Docile) # rubocop:disable RSpec/RemoveConst
 $LOADED_FEATURES.reject! { |f| f.include?("/lib/docile") }
 
 # Require Docile again, now with coverage enabled


### PR DESCRIPTION
Add 3.2 and 3.3 to testing matrix. Drop truffleruby until such time as a user mentions it, as it sometimes fails and there’s no evidence it is being used.