### PR TITLE
Fix specs on TruffleRuby

### DIFF
--- a/spec/docile_spec.rb
+++ b/spec/docile_spec.rb
@@ -546,8 +546,7 @@ describe Docile do
       it "correctly passes hash arguments" do
         described_class.dsl_eval(dsl) { configure(1, { a: 1 }) }
 
-        # TruffleRuby 22.0.0.2 has RUBY_VERSION of 3.0.2, but behaves as 2.x
-        if RUBY_VERSION >= "3.0.0" && RUBY_ENGINE != "truffleruby"
+        if RUBY_VERSION >= "3.0.0"
           expect(dsl.arguments).to eq [1, { a: 1 }]
           expect(dsl.options).to eq({})
         else


### PR DESCRIPTION
Removed a fix for TruffleRuby in specs to have them passed on the current TruffleRuby release (24.0).